### PR TITLE
[Fix]文中外链图片可能获取超时，捕获超时并跳过

### DIFF
--- a/src/article_content_spider.py
+++ b/src/article_content_spider.py
@@ -1,5 +1,6 @@
 import os
 import re
+import time
 import uuid
 import requests
 import urllib3
@@ -196,12 +197,17 @@ class ArticleContentSpider:
         for pic in pics:
             url = pic[0]  # pic url
             suffix = '.png' if not pic[1] else pic[1]  # if pic[1] is black , default .png
-            html = requests.get(url, verify=False)
-            with open(article_img_path + '\\' + str(count) + suffix, "wb")as f:
-                f.write(html.content)
-                f.seek(0)
-                f.close()
-                count += 1
+            try:
+                print("Getting pic:", url)
+                html = requests.get(url, verify=False)
+                time.sleep(3)
+                with open(article_img_path + '\\' + str(count) + suffix, "wb")as f:
+                    f.write(html.content)
+                    f.seek(0)
+                    f.close()
+                    count += 1
+            except requests.exceptions.ConnectionError:
+                print("Cannot download pic, skip this time:", pic[0])
 
     def _mkdir(self):
         """

--- a/src/article_id_spider.py
+++ b/src/article_id_spider.py
@@ -31,6 +31,8 @@ class ArticleIdSpider:
             article_ids = article_ids[1:]
             all_ids += article_ids
 
+        print("Total articles number:", len(all_ids))
+        print("Article ids:", all_ids)
         return all_ids
 
     def _fetch_content(self, url):


### PR DESCRIPTION
感谢作者，工具可以用，但是同步文章中一旦有挂掉的图片链接会报异常中断，我添加了捕获，并且由于需要登陆账号，最好控制下爬取速度（我临时在下载图片那边加了3秒sleep，以后可以改成在每个文章那边做等待），免得Csdn对账号采取异常冻结等措施 ，尤其是对博客文章非常多的博主来说。

我已经用工具同步完了260+篇自己博客的文章，稳定运行到最后。